### PR TITLE
refactor: add yup config with translations

### DIFF
--- a/src/config/yup.ts
+++ b/src/config/yup.ts
@@ -1,0 +1,13 @@
+import * as Yup from "yup";
+
+import i18n from "translations/i18n";
+
+const locale = {
+  mixed: {
+    required: i18n.t("yup.mixed_required_field"),
+  },
+};
+
+Yup.setLocale(locale);
+
+export default Yup;

--- a/src/schemas/addRepositorySchema.ts
+++ b/src/schemas/addRepositorySchema.ts
@@ -1,5 +1,5 @@
-import * as yup from "yup";
+import Yup from "config/yup";
 
-export const addRepositorySchema = yup.object().shape({
-  repositoryName: yup.string().required(),
+export const addRepositorySchema = Yup.object().shape({
+  repositoryName: Yup.string().required(),
 });

--- a/src/translations/en/common.json
+++ b/src/translations/en/common.json
@@ -10,5 +10,8 @@
   "errors": {
     "this_repository_has_already_been_added": "This repository has already been added",
     "the_repository_could_not_be_found": "This repository could not be found"
+  },
+  "yup": {
+    "mixed_required_field": "This field is required."
   }
 }

--- a/src/translations/pt/common.json
+++ b/src/translations/pt/common.json
@@ -10,5 +10,8 @@
   "errors": {
     "this_repository_has_already_been_added": "Esse repositório já foi adicionado",
     "the_repository_could_not_be_found": "Não foi possível encontrar o repositório"
+  },
+  "yup": {
+    "mixed_required_field": "Campo obrigatório."
   }
 }


### PR DESCRIPTION
## Description

This PR implements a Yup configuration in order to show translated validation error messages according to the user browser language. 

## How to test
- Blur the input with an empty text
- See the translated validation message according to your browser language